### PR TITLE
Use of hard coded passwords is a bad practice 

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,6 @@
+:hierarchy:
+  - common
+:backends:
+  - yaml
+:yaml:
+:datadir: 'hieradata'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,0 +1,2 @@
+---
+admin_pwd: a_big_secret

--- a/manifests/tempest.pp
+++ b/manifests/tempest.pp
@@ -206,7 +206,7 @@ class openstack_integration::tempest (
     identity_uri_v3                  => "${::openstack_integration::config::keystone_auth_uri}/v3",
     admin_username                   => 'admin',
     admin_project_name               => 'openstack',
-    admin_password                   => 'a_big_secret',
+    admin_password                   => hiera('admin_pwd'),
     admin_domain_name                => 'Default',
     auth_version                     => 'v3',
     tempest_roles                    => ['member', 'creator'], # needed to use barbican.


### PR DESCRIPTION
Greetings,

I am a security researcher, who is looking for security smells in Puppet scripts.
I noticed instances of hard-coded passwords, which are against the best practices
recommended by Common Weakness Enumeration (CWE) [https://cwe.mitre.org/data/definitions/259.html] and also by other security practitioners.
I suggest use of hiera to mitigate this smell. Feedback is welcome.
